### PR TITLE
Fix parse error

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -103,7 +103,7 @@ exports.encodePacket = function (packet, supportsBinary, utf8encode, callback) {
     return encodeBlob(packet, supportsBinary, callback);
   }
 
-  // might be an object with { base64: true, data: dataAsBase64String } 
+  // might be an object with { base64: true, data: dataAsBase64String }
   if (data && data.base64) {
     return encodeBase64Object(packet, callback);
   }
@@ -297,7 +297,9 @@ exports.encodePayload = function (packets, supportsBinary, callback) {
     supportsBinary = null;
   }
 
-  if (supportsBinary && hasBinary(packets)) {
+  var isBinary = hasBinary(packets);
+
+  if (supportsBinary && isBinary) {
     if (Blob && !dontSendBlobs) {
       return exports.encodePayloadAsBlob(packets, callback);
     }
@@ -314,7 +316,7 @@ exports.encodePayload = function (packets, supportsBinary, callback) {
   }
 
   function encodeOne(packet, doneCallback) {
-    exports.encodePacket(packet, supportsBinary, true, function(message) {
+    exports.encodePacket(packet, !isBinary ? false : supportsBinary, true, function(message) {
       doneCallback(null, setLengthHeader(message));
     });
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@
  */
 
 var utf8 = require('utf8');
-var hasBinary = require('has-binary');
 var after = require('after');
 var keys = require('./keys');
 
@@ -227,7 +226,7 @@ exports.encodePayload = function (packets, supportsBinary, callback) {
     supportsBinary = null;
   }
 
-  if (supportsBinary && hasBinary(packets)) {
+  if (supportsBinary) {
     return exports.encodePayloadAsBinary(packets, callback);
   }
 

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -9,3 +9,21 @@ if (Blob) {
 }
 
 require('./base64_object.js');
+
+// General browser only tests
+var parser = require('../../');
+var encode = parser.encodePacket;
+var decode = parser.decodePacket;
+var encPayload = parser.encodePayload;
+var decPayload = parser.decodePayload;
+
+describe('basic functionality', function () {
+  it('should encode string payloads as strings even if binary supported', function (done) {
+    encPayload([{ type: 'ping' }, { type: 'post' }], true, function(data) {
+      expect(data).to.be.a('string');
+      done();
+    });
+  });
+});
+
+

--- a/test/parser.js
+++ b/test/parser.js
@@ -153,15 +153,6 @@ module.exports = function(parser) {
         });
       });
 
-      describe('basic functionality', function () {
-        it('should encode string payloads as strings even if binary supported', function (done) {
-          encPayload([{ type: 'ping' }, { type: 'post' }], true, function(data) {
-            expect(data).to.be.a('string');
-            done();
-          });
-        });
-      });
-
       describe('encoding and decoding', function () {
         var seen = 0;
         it('should encode/decode packets', function (done) {


### PR DESCRIPTION
We always need to send binary when encoding payloads when sending from server to client, because the polling transport has to know the response type ahead of time.

Tests on `engine.io-client` will fail if parser is symlinked to both the server and the client without this patch.