### PR TITLE
Bump zuul and use ngrok

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,4 +1,8 @@
 ui: mocha-bdd
+tunnel:
+  type: ngrok
+  authtoken: JnawIksKFkXQzrxSjIjQ
+  proto: tcp
 browsers: 
   - name: chrome
     version: 29..latest

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "devDependencies": {
     "expect.js": "0.3.1",
     "mocha": "2.1.0",
-    "zuul": "1.10.2"
+    "zuul": "1.17.1",
+    "zuul-ngrok": "2.0.0"
   },
   "dependencies": {
     "after": "0.8.1",


### PR DESCRIPTION
Uses the new pluggable tunnel feature from Zuul.

In addition by bumping we get code coverage in the browser when running locally.